### PR TITLE
Resolve validation issue and correct style inconsistencies

### DIFF
--- a/docs/xml_mods_collections_uoft_mapping.xml
+++ b/docs/xml_mods_collections_uoft_mapping.xml
@@ -88,8 +88,8 @@ century - i.e. 15th century, 13th century, 20th century. Use decades unless coll
     </subject>
     <note>note</note>
     <note type="statement of responsibility">statement_of_responsibility</note>
-    <note type="Publication Note">publication_note</note>
-    <note type="Related Materials">related_materials_note</note>
+    <note type="publication note">publication_note</note>
+    <note type="related materials">related_materials_note</note>
     <note type="ownership" displayLabel="Provenance">provenance</note>
     <relatedItem type="host" displayLabel="Part Of"><!-- no need to add unless item is part of bigger archival collection; commonly used for linking to archival collections or fonds in Discover Archives -->
         <titleInfo>
@@ -106,8 +106,8 @@ century - i.e. 15th century, 13th century, 20th century. Use decades unless coll
             <title>part_of_constituent</title>
         </titleInfo>
         <name>
-        <namePart>part_of_constituent_creator</namePart>
-    </name>
+            <namePart>part_of_constituent_creator</namePart>
+        </name>
     </relatedItem>
     <accessCondition type="use and reproduction">rights_note</accessCondition>
     <accessCondition type="restriction on access">rights_facet</accessCondition>

--- a/docs/xml_mods_collections_uoft_mapping.xml
+++ b/docs/xml_mods_collections_uoft_mapping.xml
@@ -81,9 +81,13 @@ century - i.e. 15th century, 13th century, 20th century. Use decades unless coll
     </subject>
     <subject>
         <cartographics>
-            <coordinates>coordinates</coordinates>
-            <scale>scale</scale>
-            <projection>projection</projection>
+          <coordinates>coordinates</coordinates>
+        </cartographics>
+        <cartographics>
+          <scale>scale</scale>
+        </cartographics>
+        <cartographics>
+          <projection>projection</projection>
         </cartographics>
     </subject>
     <note>note</note>


### PR DESCRIPTION
1. Fixed MODS validation error related to 'scale' element.
    
MODS schema validation reported following error:
```
Invalid content was found starting with element '{"http://www.loc.gov/mods/v3":scale}'. One of '{"http://www.loc.gov/mods/v3":coordinates, "http://www.loc.gov/mods/v3":cartographicExtension}' is expected.
```
Nesting the <scale> element within a separate <cartographics /> tag resolved the issue.

2. Normalized casing of 'type' attributes and indentation of 'name' tag
